### PR TITLE
docs: remove per-page JS RUM snippets, update main.html for auto page tracking

### DIFF
--- a/docs/2-getting-started.md
+++ b/docs/2-getting-started.md
@@ -1,4 +1,3 @@
---8<-- "snippets/send-bizevent/2-getting-started.js"
 # Getting Started
 
 ## Prerequisites

--- a/docs/3-data-transformation.md
+++ b/docs/3-data-transformation.md
@@ -1,6 +1,5 @@
 # Data Transformation
 
---8<-- "snippets/send-bizevent/3-data-transformation.js"
 
 In this lab module, we will explore how to transform data from various sources using `join`, `lookup`, `append`, and `data` commands. We will look at data from logs, traces, the entity model, and raw sources to accomplish this.
 

--- a/docs/4-wrap-up.md
+++ b/docs/4-wrap-up.md
@@ -1,6 +1,5 @@
 # Wrap Up
 
---8<-- "snippets/send-bizevent/4-wrap-up.js"
 
 ### What You Learned Today 
 You explored how to connect data using the `append`, `data`, `lookup`, and `join` commands in DQL to combine data from multiple sources. 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,4 +1,3 @@
---8<-- "snippets/send-bizevent/index.js"
 
 --8<-- "snippets/dt-enablement.md"
 

--- a/docs/overrides/main.html
+++ b/docs/overrides/main.html
@@ -8,3 +8,16 @@
     crossorigin="anonymous"></script>
   {% endif %}
 {% endblock %}
+
+{% block scripts %}
+  {{ super() }}
+  {% if config.extra.rum_snippet and page is defined and page.title %}
+  <script>
+    document.addEventListener('DOMContentLoaded', function() {
+      if (typeof dynatrace !== 'undefined') {
+        dynatrace.sendBizEvent('page_load', {'page': {{ page.title | tojson }}});
+      }
+    });
+  </script>
+  {% endif %}
+{% endblock %}

--- a/docs/snippets/send-bizevent/2-getting-started.js
+++ b/docs/snippets/send-bizevent/2-getting-started.js
@@ -1,5 +1,0 @@
-<script>
-document.addEventListener('DOMContentLoaded', function() {
-  dynatrace.sendBizEvent('page_load', {"page": "2. Getting Started"})
-});
-</script>

--- a/docs/snippets/send-bizevent/3-data-transformation.js
+++ b/docs/snippets/send-bizevent/3-data-transformation.js
@@ -1,5 +1,0 @@
-<script>
-document.addEventListener('DOMContentLoaded', function() {
-  dynatrace.sendBizEvent('page_load', {"page": "3. Data Transformation"})
-});
-</script>

--- a/docs/snippets/send-bizevent/4-wrap-up.js
+++ b/docs/snippets/send-bizevent/4-wrap-up.js
@@ -1,5 +1,0 @@
-<script>
-document.addEventListener('DOMContentLoaded', function() {
-  dynatrace.sendBizEvent('page_load', {"page": "4. Wrap Up"})
-});
-</script>

--- a/docs/snippets/send-bizevent/index.js
+++ b/docs/snippets/send-bizevent/index.js
@@ -1,5 +1,0 @@
-<script>
-document.addEventListener('DOMContentLoaded', function() {
-  dynatrace.sendBizEvent('page_load', {"page": "1. About"})
-});
-</script>


### PR DESCRIPTION
## Summary

- Removes all `docs/snippets/*.js` files (per-page RUM bizEvent scripts)
- Removes `--8<-- "snippets/*.js"` includes from all markdown pages
- Updates `docs/overrides/main.html` to the framework v1.3.0 template

## Why

Page tracking via BizEvents is now handled centrally by `docs/overrides/main.html`, which:
1. Loads the RUM agent from `extra.rum_snippet` in `mkdocs.yaml`
2. Fires a `page_load` BizEvent on every page using the page title from the `nav` definition

Per-page JS snippet files were redundant and required manual maintenance for each new page.

## Test plan
- [ ] Verify docs build succeeds in CI
- [ ] Confirm no broken snippet includes remain in markdown files

🤖 Generated with [Claude Code](https://claude.com/claude-code)